### PR TITLE
Add information about BAPC 2019

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -174,6 +174,9 @@
 <div class="container">
     <div class="row">
         <div class="col-sm-12">
+            <h2>The BAPC 2019 is starting up</h2>
+            <p>For information about the BAPC 2019, you can <a href="https://2019.bapc.eu">view the new website here</a></p>
+            <br>
             <h2>{{ page.title }}</h2>
             {{ content }}
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -174,7 +174,7 @@
 <div class="container">
     <div class="row">
         <div class="col-sm-12">
-            <h2>The BAPC 2019 is starting up</h2>
+            <h2>The BAPC 2019 is starting up!</h2>
             <p>For information about the BAPC 2019, you can <a href="https://2019.bapc.eu">view the new website here</a></p>
             <br>
             <h2>{{ page.title }}</h2>


### PR DESCRIPTION
We are having some issues with getting the redirect for BAPC 2019 working, so it would be nice to get the information about the new site on the 2018 site.